### PR TITLE
Add message to runautodq in setautodq

### DIFF
--- a/tournaments/index.js
+++ b/tournaments/index.js
@@ -866,6 +866,7 @@ var commands = {
 			if (tournament.setAutoDisqualifyTimeout(timeout * 60 * 1000, this)) {
 				this.privateModCommand("(The tournament auto disqualify timeout was set to " + params[0] + " by " + user.name + ")");
 			}
+			user.send('Kindly run `/tour runautodq` for the timeout to function.');
 		},
 		runautodq: function (tournament) {
 			tournament.runAutoDisqualify(this);


### PR DESCRIPTION
This is just so whoever sets the autodq time remembers to emit the runautodq command as well.
