### PR TITLE
DON'T MERGE - Rand LC sets

### DIFF
--- a/data/formats-data.js
+++ b/data/formats-data.js
@@ -839,7 +839,7 @@ exports.BattleFormatsData = {
 		tier: "NU"
 	},
 	tyrogue: {
-		randomBattleMoves: ["highjumpkick","rapidspin","fakeout","bulletpunch","machpunch","toxic","counter"],
+		randomBattleMoves: ["rapidspin","machpunch","highjumpkick","earthquake","toxic","counter"],
 		randomDoubleBattleMoves: ["highjumpkick","feint","fakeout","bulletpunch","machpunch","helpinghand","protect"],
 		tier: "LC"
 	},
@@ -1353,7 +1353,7 @@ exports.BattleFormatsData = {
 		tier: "RU"
 	},
 	dratini: {
-		randomBattleMoves: ["dragondance","outrage","waterfall","fireblast","extremespeed","dracometeor","substitute","aquatail"],
+		randomBattleMoves: ["dragondance","outrage","extremespeed","irontail","fireblast","thunderwave"],
 		tier: "LC"
 	},
 	dragonair: {
@@ -1737,7 +1737,7 @@ exports.BattleFormatsData = {
 		tier: "OU"
 	},
 	snubbull: {
-		randomBattleMoves: ["thunderwave","firepunch","crunch","closecombat","icepunch","earthquake","playrough"],
+		randomBattleMoves: ["thunderwave","thief","closecombat","icepunch","crunch","earthquake","playrough"],
 		eventPokemon: [
 			{"generation":3,"level":10,"gender":"M","moves":["tackle","scaryface","tailwhip","charm"]}
 		],
@@ -2103,7 +2103,7 @@ exports.BattleFormatsData = {
 		tier: "NU"
 	},
 	zigzagoon: {
-		randomBattleMoves: ["trick","thunderwave","icebeam","thunderbolt","gunkshot","lastresort"],
+		randomBattleMoves: ["bellydrum","extremespeed","thief","seedbomb","gunkshot"],
 		eventPokemon: [
 			{"generation":3,"level":5,"shiny":true,"abilities":["pickup"],"moves":["tackle","growl","tailwhip"]},
 			{"generation":3,"level":5,"abilities":["pickup"],"moves":["tackle","growl","extremespeed"]}
@@ -3912,7 +3912,7 @@ exports.BattleFormatsData = {
 		tier: "NU"
 	},
 	roggenrola: {
-		randomBattleMoves: ["autotomize","stoneedge","stealthrock","rockblast","earthquake","explosion"],
+		randomBattleMoves: ["autotomize","stoneedge","stealthrock",,"earthquake","explosion"],
 		tier: "LC"
 	},
 	boldore: {
@@ -4125,7 +4125,7 @@ exports.BattleFormatsData = {
 		tier: "NU"
 	},
 	archen: {
-		randomBattleMoves: ["stoneedge","rockslide","earthquake","uturn","pluck","headsmash"],
+		randomBattleMoves: ["defog","rockslide","acrobatics","uturn","stealthrock","earthquake"],
 		eventPokemon: [
 			{"generation":5,"level":15,"gender":"M","moves":["headsmash","wingattack","doubleteam","scaryface"],"pokeball":"cherishball"}
 		],
@@ -4137,7 +4137,7 @@ exports.BattleFormatsData = {
 		tier: "NU"
 	},
 	trubbish: {
-		randomBattleMoves: ["clearsmog","toxicspikes","spikes","gunkshot","painsplit","toxic"],
+		randomBattleMoves: ["recycle","spikes","drainpunch","gunkshot","explosion","toxicspikes"],
 		tier: "LC"
 	},
 	garbodor: {
@@ -4815,7 +4815,7 @@ exports.BattleFormatsData = {
 		tier: "Uber"
 	},
 	spritzee: {
-		randomBattleMoves: ["calmmind","drainingkiss","moonblast","psychic","aromatherapy","wish","trickroom","thunderbolt"],
+		randomBattleMoves: ["moonblast","wish","protect","aromatherapy","psychic","calmmind"],
 		tier: "LC"
 	},
 	aromatisse: {
@@ -4955,21 +4955,21 @@ exports.BattleFormatsData = {
 		tier: "UU"
 	},
 	pumpkaboo: {
-		randomBattleMoves: ["willowisp","shadowsneak","fireblast","painsplit","seedbomb"],
+		randomBattleMoves: ["leechseed","willowisp","phantomforce","shadowsneak","fireblast","seedbomb"],
 		tier: "LC"
 	},
 	pumpkaboosmall: {
-		randomBattleMoves: ["willowisp","shadowsneak","fireblast","painsplit","seedbomb"],
+		randomBattleMoves: ["leechseed","willowisp","phantomforce","shadowsneak","fireblast","seedbomb"],
 		unreleasedHidden: true,
 		tier: "LC"
 	},
 	pumpkaboolarge: {
-		randomBattleMoves: ["willowisp","shadowsneak","fireblast","painsplit","seedbomb"],
+		randomBattleMoves: ["leechseed","willowisp","phantomforce","shadowsneak","fireblast","seedbomb"],
 		unreleasedHidden: true,
 		tier: "LC"
 	},
 	pumpkaboosuper: {
-		randomBattleMoves: ["willowisp","shadowsneak","fireblast","painsplit","seedbomb"],
+		randomBattleMoves: ["leechseed","willowisp","phantomforce","shadowsneak","fireblast","seedbomb"],
 		unreleasedHidden: true,
 		tier: "LC"
 	},


### PR DESCRIPTION
DON'T MERGE - I'll add more tomorrow and also edit the items accordingly via Goddess Briyella.

First number of edited sets: Tyrogue, Dratini, Snubbull, Zigzagoon, Roggenrola, Archen, Trubbish, Spritzee, Pumpkaboos.
