### PR TITLE
Muted and locked users cannot kick others

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -650,6 +650,7 @@ var commands = exports.commands = {
  	roomkick: function(target, room, user){
  		//if (!room.auth && room.id !== "staff") return this.sendReply('/rkick is designed for rooms with their own auth.');
  		if (!this.can('roommod', null, room)) return false;
+ 		if (!this.canTalk()) return;
  		if (!target) return this.sendReply('/rkick [username] - kicks the user from the room. Requires: @ & ~');
 
  		target = this.splitTarget(target);


### PR DESCRIPTION
People have been abusing the /kick [user], [message] command to evade punishments suck as mutes and locks to still be able to talk.

Example: http://i.imgur.com/Wz2CrFM.png