### PR TITLE
Get rid of white background

### DIFF
--- a/config/custom.css
+++ b/config/custom.css
@@ -8,7 +8,7 @@ display:none;
 }
 
 body {
-	background:#ffffff;
+	background: url(http://frostserver.net:8000/images/background1.jpg);
 }
 
 .backdrop {
@@ -66,7 +66,7 @@ body {
 }
 
 .mainmenuwrapper {
-	background-image:url("http://frostserver.net:8000/images/background1.jpg");
+	background-image: none !important;
 }
 
 .chat-log {


### PR DESCRIPTION
If you have too many chat boxes, you can see the background stays at the top while showing a white bottom so this just makes it so that you always see the background :100:  :8ball: 