### PR TITLE
Users unanble to talk cannot use roomdesc

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -635,6 +635,7 @@ var commands = exports.commands = {
 			return;
 		}
 		if (!this.can('roommod', null, room)) return false;
+		if (!this.canTalk()) return false;
 		if (target.length > 80) return this.sendReply("Error: Room description is too long (must be at most 80 characters).");
 
 		room.desc = target;


### PR DESCRIPTION
People have been evading punishments where they cannot talk to use the ``roomdesc`` command to communicate with others.