### PR TITLE
A command to get the link to a room

### DIFF
--- a/config/commands.js
+++ b/config/commands.js
@@ -388,6 +388,14 @@ var commands = exports.commands = {
 	 	}
 	 	return this.sendReply("Group \"" + target + "\" not found.");
 	 },
+	
+	roomlink: 'room',
+	viewroom: 'room',
+	room: function (target, room, user) {
+		if (!this.canBroadcast()) return;
+		var msg = "A link to this room can be found here: <a href=\"http://frostserver.net/" + room.id + "\">http://frostserver.net/" + room.id + "</a>";
+		this.sendReplyBox(msg);
+	},
 
 	poke: function (target, room, user) {
 		if (!target) return this.sendReply('/poke needs a target.');


### PR DESCRIPTION
Because of the custom client, when we join a room such as a battle, it defaults to the same custom client link.  So, for regular users, it might be hard for them to find the link to their battle, for example.

This command eases that.